### PR TITLE
Add a test for checking the calculated cpu percent.

### DIFF
--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -16,7 +16,7 @@ var getUsage = function(cb) {
   });
 };
 
-var alreadySendingToKey = {};
+var checkInterval = {};
 
 module.exports = function(influxclient) {
 
@@ -25,6 +25,13 @@ module.exports = function(influxclient) {
     var seriesName = 'cpuUsed';
     var workerId = process.env.metricsId || 'master';
     var cacheKey = key + seriesName + workerId;
+    if (opts.stop) {
+      if (checkInterval[cacheKey]) {
+        clearInterval(checkInterval[cacheKey]);
+        delete checkInterval[cacheKey];
+      }
+      return cb();
+    }
     var usageFunc = opts.getUsage ? opts.getUsage : getUsage;
     var handleError = function(err) {
       console.error("error getting cpu usage ",err);
@@ -33,15 +40,13 @@ module.exports = function(influxclient) {
       }
     };
 
-    if (alreadySendingToKey[cacheKey]) {
+    if (checkInterval[cacheKey]) {
       cb('Already sending ' + seriesName + ' to ' + key);
     } else {
-      alreadySendingToKey[cacheKey] = true;
-
       var interval = opts.interval || 2000; // how often to poll
       var period = opts.period || 1000; // period to measure
 
-      setInterval(function() {
+      checkInterval[cacheKey] = setInterval(function() {
         usageFunc(function(err, startTime) {
           if (err) {
             return handleError(err);


### PR DESCRIPTION
This change highlighted an issue with the tests that leaves intervals
running indefinitely for the duration of the test run.
This causes unusual behaviour, such as assertion blocks being called
multiple times.
To mitigate this during testing, a 'stop' feature was added to allow
stopping the cpu check interval for a specific component, thereby
allowing more control in tests