### PR TITLE
Remove console error when cannot get CPU usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,7 @@ NOTE: each record will be added to a list in Redis. The key for the list is the 
 * tags
 * fields
 * ts
+
+# Limitations
+
+CPU metrics are supported only on Linux based operating systems.

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -36,8 +36,6 @@ module.exports = function(metricsClients) {
     }
     var usageFunc = opts.getUsage ? opts.getUsage : getUsage;
     var handleError = function(err) {
-      /*eslint-disable no-console */
-      console.error("error getting cpu usage ",err);
       if ('function' === typeof cb) {
         return cb(err);
       }


### PR DESCRIPTION
Stats module should not use console error as it quickly fills out logs. 
There may be numerous cases when cpu usage cannot be collected (for example darwin environment etc.)