### PR TITLE
 ✨ add support for base tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here are the steps to use this module in an existing RHMAP component:
 
     ```
     var fhComponentMetrics = require('fh-component-metrics');
-    var metricsConf = {enabled: true, host: '1.2.3.4', port: 2003};
+    var metricsConf = {enabled: true, host: '1.2.3.4', port: 2003, baseTags: {appId: process.env.APPID}};
     var metrics = fhComponentMetrics(metricsConf);
     var TITLE = 'myTestComponent';
     metrics.memory(TITLE, { interval: 2000 }, function(err) {
@@ -41,7 +41,7 @@ Here are the steps to use this module in an existing RHMAP component:
 
    ```
    var fhComponentMetrics = require('fh-component-metrics');
-   var metricsConf = {enabled: true, backends:[{type: 'influxdb', host: '1.2.3.4', port: 2003}, {type: 'statsd', host: '1.2.3.4', port: 2004}];
+   var metricsConf = {enabled: true, backends:[{type: 'influxdb', host: '1.2.3.4', port: 2003}, {type: 'statsd', host: '1.2.3.4', port: 2004}], baseTags: {appId: process.env.APPID}};
    var metrics = fhComponentMetrics(metricsConf);
    //the metrics data will be sent to both the influxdb and statsd backend
    ```
@@ -52,7 +52,7 @@ At the moment, it supports Influxdb, Statsd and redis, so the valid options for 
 
     ```
     var fhComponentMetrics = require('fh-component-metrics');
-    var metricsConf = {enabled: true, host: '1.2.3.4', port: 2003};
+    var metricsConf = {enabled: true, host: '1.2.3.4', port: 2003, baseTags: {appId: process.env.APPID}};
     var app = express();
     app.use(fhComponentMetrics.timingMiddleware('myExpressApp', metricsConf));
     ```

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var MetricsClients = require('./lib/clients');
+var types = require('./lib/types');
 
 module.exports = function metrics(conf) {
   //configure config module
@@ -12,7 +13,7 @@ module.exports = function metrics(conf) {
   return {
     "cpu": confEnabled ? require('./lib/cpu')(clients, baseTags) : nothing,
     "memory": confEnabled ? require('./lib/memory')(clients, baseTags) : nothing,
-    "gauge": confEnabled ? require('./lib/gauge')(clients, baseTags) : nothing,
+    "gauge": confEnabled ? require('./lib/gauge')(clients, types.G, baseTags) : nothing,
     "inc": confEnabled ? counter.inc : nothing,
     "dec": confEnabled ? counter.dec : nothing,
     "timer": confEnabled ? require('./lib/timer')(clients, baseTags) : nothing

--- a/index.js
+++ b/index.js
@@ -5,16 +5,17 @@ module.exports = function metrics(conf) {
   var config = require('./lib/config')(conf);
   var confEnabled = config.enabled();
   var clients = new MetricsClients(config.getConfig());
-  var counter = require('./lib/counter')(clients);
+  var baseTags = config.getBaseTags();
+  var counter = require('./lib/counter')(clients, baseTags);
   var nothing = function() {};
 
   return {
-    "cpu": confEnabled ? require('./lib/cpu')(clients) : nothing,
-    "memory": confEnabled ? require('./lib/memory')(clients) : nothing,
-    "gauge": confEnabled ? require('./lib/gauge')(clients) : nothing,
+    "cpu": confEnabled ? require('./lib/cpu')(clients, baseTags) : nothing,
+    "memory": confEnabled ? require('./lib/memory')(clients, baseTags) : nothing,
+    "gauge": confEnabled ? require('./lib/gauge')(clients, baseTags) : nothing,
     "inc": confEnabled ? counter.inc : nothing,
     "dec": confEnabled ? counter.dec : nothing,
-    "timer": confEnabled ? require('./lib/timer')(clients) : nothing
+    "timer": confEnabled ? require('./lib/timer')(clients, baseTags) : nothing
   };
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -24,6 +24,13 @@ module.exports = function(config) {
       }
       return config.port;
     },
+    "getBaseTags": function() {
+      if (config.baseTags && typeof config.baseTags === 'object') {
+        return config.baseTags;
+      } else {
+        return {};
+      }
+    },
     "enabled": function() {
       return (config.enabled === true || config.enabled === 'true') && backends.length > 0;
     }

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -1,9 +1,9 @@
 var gauge = require('./gauge');
 var types = require('./types');
 
-module.exports = function(metricsClients) {
+module.exports = function(metricsClients, baseTags) {
 
-  var g = gauge(metricsClients, types.C);
+  var g = gauge(metricsClients, types.C, baseTags);
 
   return {
     'inc': function(key, tags, cb) {

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var os = require('os');
 var types = require('./types');
+var _ = require('lodash');
 
 // http://stackoverflow.com/a/7774034/2829381
 var getUsage = function(cb) {
@@ -20,7 +21,7 @@ var getUsage = function(cb) {
 
 var checkInterval = {};
 
-module.exports = function(metricsClients) {
+module.exports = function(metricsClients, baseTags) {
 
   return function cpu(component, opts, cb) {
     var key = component + '_cpu';
@@ -72,10 +73,10 @@ module.exports = function(metricsClients) {
               var data = {};
               data.type = types.G;
               data.key = key;
-              data.tags = {
+              data.tags = _.assign({
                 hostname: os.hostname(),
                 workerId: workerId
-              };
+              }, baseTags);
               data.fields = point;
               data.timestamp = Date.now();
 

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -1,16 +1,15 @@
 var os = require('os');
 var types = require('./types');
+var _ = require('lodash');
 
-module.exports = function(metricsClients, type) {
+module.exports = function(metricsClients, type, baseTags) {
 
   return function(key, tag, value, cb) {
     var data = {};
     //the type of the metric
     data.type = type || types.G;
     data.key = key;
-    data.tags = tag || {};
-    data.tags.hostname = os.hostname();
-    data.tags.workerId = process.env.metricsId || 'master';
+    data.tags = _.assign({hostname: os.hostname(), workerId: process.env.metricsId || 'master'}, baseTags, tag || {});
     data.fields = {value: value};
     data.timestamp = Date.now();
     metricsClients.send.call(metricsClients, data);

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -1,8 +1,9 @@
 var os = require('os');
 var types = require('./types');
 var alreadySendingToKey = {};
+var _ = require('lodash');
 
-module.exports = function(metricsClients) {
+module.exports = function(metricsClients, baseTags) {
 
   function getHeap() {
     var mem = process.memoryUsage();
@@ -29,10 +30,10 @@ module.exports = function(metricsClients) {
         var data = {};
         data.type = types.G;
         data.key = key;
-        data.tags = {
+        data.tags = _.assign({
           hostname: os.hostname(),
           workerId: workerId
-        };
+        }, baseTags);
         data.fields = getHeap();
         data.timestamp = Date.now();
         metricsClients.send.call(metricsClients, data);

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -1,9 +1,9 @@
 var gauge = require('./gauge');
 var types = require('./types');
 
-module.exports = function(metricsClients) {
+module.exports = function(metricsClients, baseTags) {
 
-  var g = gauge(metricsClients, types.T);
+  var g = gauge(metricsClients, types.T, baseTags);
 
   return function(key, tags, value, cb) {
     g(key, tags, value, cb);

--- a/lib/timingMiddleware.js
+++ b/lib/timingMiddleware.js
@@ -7,7 +7,7 @@ module.exports = function timingMiddlewareCreator(component, metrics_conf) {
   var config = require('./config')(metrics_conf);
   var metricsEnabled = config.enabled();
   var clients = metricsEnabled ? new MetricsClients(config.getConfig()) : null;
-  var timeFunc = metricsEnabled ? gauge(clients, types.T) : null;
+  var timeFunc = metricsEnabled ? gauge(clients, types.T, config.getBaseTags()) : null;
 
   return function timingMiddleware(req, res, next) {
     if (metricsEnabled) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-component-metrics",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "dependencies": {
     "async": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-component-metrics",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "influx db metrics wrapper",
   "main": "index.js",
   "scripts": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-component-metrics
 sonar.projectName=fh-component-metrics-nightly-master
-sonar.projectVersion=2.6.1
+sonar.projectVersion=2.7.0
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/unit/testCpu.js
+++ b/test/unit/testCpu.js
@@ -9,7 +9,8 @@ var mocks = {
   }
 };
 
-var metrics = proxyquire('index.js', mocks)({enabled: true, host: '127.0.0.1'});
+var idField = "testCpu";
+var metrics = proxyquire('index.js', mocks)({enabled: true, host: '127.0.0.1', baseTags: {id: idField}});
 var component = 'testComponent';
 
 var customGetUsage = function(cb) {
@@ -38,6 +39,7 @@ exports.cpu_should_send_valid_object = function(finish) {
     assert.ok(data.hasOwnProperty('tags'));
     assert.equal(data.tags.hostname, os.hostname());
     assert.equal(data.tags.workerId, 'master');
+    assert.equal(data.tags.id, idField);
     if (!called) {
       called = true;
       finish();

--- a/test/unit/testGauge.js
+++ b/test/unit/testGauge.js
@@ -5,7 +5,8 @@ var clientsMock =  {
   send: function() {}
 };
 
-var timed = require('gauge')(clientsMock, types.G);
+var idField = 'testgauge';
+var timed = require('gauge')(clientsMock, types.G, {id: idField});
 
 exports.timed_should_send_valid_object = function(done) {
   timed('testKey', {route: '/api/test'}, 100, function(err, data) {
@@ -16,6 +17,7 @@ exports.timed_should_send_valid_object = function(done) {
     assert.ok(data.hasOwnProperty('fields'));
     assert.equal(data.fields.value, 100);
     assert.equal(data.tags.route, '/api/test');
+    assert.equal(data.tags.id, idField);
     done();
   });
 };

--- a/test/unit/testMemory.js
+++ b/test/unit/testMemory.js
@@ -8,7 +8,8 @@ var mocks = {
   }
 };
 
-var metrics = proxyquire('index.js', mocks)({enabled: true, host: '127.0.0.1'});
+var idField = "testmemeory";
+var metrics = proxyquire('index.js', mocks)({enabled: true, host: '127.0.0.1', baseTags: {id: idField}});
 
 exports.mem_should_send_valid_object = function(finish) {
 
@@ -26,6 +27,7 @@ exports.mem_should_send_valid_object = function(finish) {
     assert.ok(data.hasOwnProperty('tags'));
     assert.equal(data.tags.hostname, os.hostname());
     assert.equal(data.tags.workerId, 'master');
+    assert.equal(data.tags.id, idField);
     if (!called) {
       called = true;
       finish();


### PR DESCRIPTION
## Why

In some use cases, it is required to add some meta data for every metric data. The only to do it at the moment is to add them individually for every call. It is not necessary as it's the same data being applied.

## What

This PR will allow users to specify `baseTags` object when initialise the metrics client. Then the `baseTags` will be added automatically to every metric data as part of the tags.

ping @aidenkeating @david-martin for review